### PR TITLE
Tabular data with description of changeset does not break layout with long words

### DIFF
--- a/gradle/changelog/table_word_break.yaml
+++ b/gradle/changelog/table_word_break.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix word break on table layout ([#6](https://github.com/scm-manager/scm-history-download-plugin/pull/6))

--- a/src/main/js/FileHistory.tsx
+++ b/src/main/js/FileHistory.tsx
@@ -36,6 +36,7 @@ import { SelectedFile, useFileTreeContext } from "./context";
 import { File, Link } from "@scm-manager/ui-types";
 import { useHistoryDownload } from "./useHistoryDownload";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components";
 
 type DownloadLinkProps = {
   file: File;
@@ -72,6 +73,10 @@ const FetchMore: FC<FetchMoreProps> = ({ fetchNextPage }) => {
     </LinkStyleButton>
   );
 };
+
+const DescriptionTableData = styled.td`
+  overflow-wrap: anywhere;
+`;
 
 type ControlProps = {
   isFetchingNextPage: boolean;
@@ -128,7 +133,7 @@ const FileHistoryTable: FC<TableProps> = ({ repository, revision, file, close })
             <td>
               <DateFromNow date={c.date} />
             </td>
-            <td>{c.description}</td>
+            <DescriptionTableData>{c.description}</DescriptionTableData>
             <td>
               <DownloadLink file={file} />
             </td>

--- a/src/main/js/FileHistory.tsx
+++ b/src/main/js/FileHistory.tsx
@@ -148,7 +148,7 @@ const FileHistory: FC<extensionPoints.ReposSourcesTreeRowProps> = ({ file }) => 
 
   return (
     <tr>
-      <td colSpan={42}>
+      <td colSpan={6}>
         <FileHistoryTable {...selectedFile} close={unselect} />
       </td>
     </tr>

--- a/src/main/js/FileHistory.tsx
+++ b/src/main/js/FileHistory.tsx
@@ -36,7 +36,6 @@ import { SelectedFile, useFileTreeContext } from "./context";
 import { File, Link } from "@scm-manager/ui-types";
 import { useHistoryDownload } from "./useHistoryDownload";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
 
 type DownloadLinkProps = {
   file: File;
@@ -73,10 +72,6 @@ const FetchMore: FC<FetchMoreProps> = ({ fetchNextPage }) => {
     </LinkStyleButton>
   );
 };
-
-const DescriptionTableData = styled.td`
-  overflow-wrap: anywhere;
-`;
 
 type ControlProps = {
   isFetchingNextPage: boolean;
@@ -133,7 +128,7 @@ const FileHistoryTable: FC<TableProps> = ({ repository, revision, file, close })
             <td>
               <DateFromNow date={c.date} />
             </td>
-            <DescriptionTableData>{c.description}</DescriptionTableData>
+            <td className="is-word-break">{c.description}</td>
             <td>
               <DownloadLink file={file} />
             </td>


### PR DESCRIPTION


## Proposed changes

The description of a changeset should break its content, not ~~hearts~~ the table. Setting the whole table to a fixed layout would create new issues regarding column-width and was therefore not used.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Please ensure the "what" and "why" are explained properly in this description as it will be used as the commit description on squashing your pull request commits. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
